### PR TITLE
Added `string[]` as valid type for `scope` in config

### DIFF
--- a/packages/okta-angular/src/okta/okta.config.ts
+++ b/packages/okta-angular/src/okta/okta.config.ts
@@ -16,7 +16,7 @@ export interface OktaConfig {
   issuer?: string;
   redirectUri?: string;
   clientId?: string;
-  scope?: string;
+  scope?: string | string[];
   onAuthRequired?: Function;
 }
 


### PR DESCRIPTION
The actual JavaScript for `OktaAuthModule` accepts a string array for the `scope` property of the config; however, the faulty type definition causes compilation to fail when `scope` is an array.